### PR TITLE
Misc quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,15 @@ ENV/
 # mypy
 .mypy_cache/
 
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode
+
 .DS_Store
 
 .autoversion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,18 @@
 
 Thank you for your interest in contributing to jupyter-fs!
 
-We invite you to contribute enhancements. Upon review you will be required to complete the [Contributor License Agreement (CLA)](https://github.com/jpmorganchase/cla) before we are able to merge. 
+We invite you to contribute enhancements. Upon review you will be required to complete the [Contributor License Agreement (CLA)](https://github.com/jpmorganchase/cla) before we are able to merge.
 
 If you have any questions about the contribution process, please feel free to send an email to [open_source@jpmorgan.com](mailto:open_source@jpmorgan.com).
+
+## Install for Development
+
+```bash
+# first cd to your jupyter-fs repo dir, then
+pip install -e .
+jupyter serverextension enable --py jupyterfs
+jupyter labextension link .
+```
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ A filesystem-like `ContentsManager` backend for Jupyter. This library allows you
 
 ```bash
 pip install jupyter-fs
-jupyter labextension install jupyter-fs
-jupyter serverextension enable --py jupyter-fs
 ```
 
 
@@ -78,7 +76,7 @@ c.MultiContentsManager.contents_managers = \
 
 Here I utilize an `AbsolutePathFileManager` to grab another folder on my system for use. Remember, remote filesystems are still remote, and locally you may need to move around the filesystem with a `os.chdir` command (or equivalent in other languages).
 
-Here, I have the above `s3` and `AbsolutePathFileManager`, along with the original contents manager, for a total of 3 seperate spaces. 
+Here, I have the above `s3` and `AbsolutePathFileManager`, along with the original contents manager, for a total of 3 seperate spaces.
 
 ![](https://raw.githubusercontent.com/timkpaine/jupyter-fs/master/docs/example2.gif)
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:integrity": "jlpm install && jlpm build",
     "build:lab": "rimraf lab-dist && mkdirp lab-dist && cd lab-dist && npm pack ..",
-    "build:all": "npm run build && npm run build:lab",
+    "build:all": "jlpm run build:integrity && jlpm run build:lab",
     "clean": "rimraf lib",
     "fix": "./node_modules/.bin/tslint --fix src/* src/*/*",
     "lint": "./node_modules/.bin/tslint './src/*.ts'",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "jlpm run build",
     "test": "jest --coverage --collectCoverageFrom=src/*.{ts}"
   },
   "files": [
@@ -49,15 +50,15 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.5.5",
-    "@types/jest": "^24.0.4",
+    "@types/jest": "^24",
     "babel-jest": "^24.8.0",
     "isomorphic-fetch": "^2.2.1",
-    "jest": "^24.1.0",
+    "jest": "^24",
     "jest-transform-css": "^2.0.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.3",
-    "ts-jest": "^23.10.4",
+    "ts-jest": "^24",
     "tslint": "^5.20.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "jupyter-packaging"]
+requires = ["setuptools", "wheel", "jupyter-packaging", "jupyterlab"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ description_file = README.md
 
 [flake8]
 max-line-length=200
+exclude =
+    setup.py
 
 [manifix]
 known-excludes =


### PR DESCRIPTION
- Big one is preventing build/install of TS package on running `pip install -e .`. For a dev install, you instead want to separately install the TS package using `jupyter labextension link .`

- Removed the explicit `jupyter serverextension enable --py jupyterfs` command from the readme install instructions (it shouldn't be needed). Ideally, the command shouldn't be needed for a dev install either, but my current solutions for that particular problem apparently don't work when a custom pyproject.toml is in play