### PR TITLE
Generate python coverage report.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ testjs: ## Clean and Make js tests
 	yarn test
 
 testpy: ## Clean and Make py tests
-	python3.7 -m pytest -v jupyterfs/tests --cov=jupyterfs --cov-branch
+	python3.7 -m pytest -v jupyterfs/tests --cov=jupyterfs --cov-branch --junitxml=python --cov-report=xml
 
 test: ## run all tests
 	testpy


### PR DESCRIPTION
Coverage is missing; shield shows 0% on github, and there's a warning during the build:

![Screenshot from 2020-04-16 16-25-14](https://user-images.githubusercontent.com/1929/79475064-1c83a900-7fff-11ea-8fea-241688c13432.png)


Not sure if you want to generate a coverage report every time you do `make testpy`? If not, let me know what you prefer.