### PR TITLE
Allow for release on pypi by applying diff from althonos/fs.smbfs#11 as a monkeypatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
+PIP := pip
+PYTHON := python
+YARN := jlpm
+
 testjs: ## Clean and Make js tests
-	yarn test
+	${YARN} test
 
 testpy: ## Clean and Make py tests
-	python3.7 -m pytest -v jupyterfs/tests --cov=jupyterfs --cov-branch --junitxml=python_junit.xml --cov-report=xml
+	${PYTHON} -m pytest -v jupyterfs/tests --cov=jupyterfs --cov-branch --junitxml=python_junit.xml --cov-report=xml
 
 testbrowser:
-	yarn test:browsercheck
+	${YARN} test:browsercheck
 
 test: ## run all tests
 	make testjs
@@ -16,7 +20,7 @@ lintjs: ## run linter
 	./node_modules/.bin/tslint src/* src/*/*
 
 lintpy: ## run linter
-	python3.7 -m flake8 jupyterfs setup.py
+	${PYTHON} -m flake8 jupyterfs setup.py
 
 lint: ## run linter
 	make lintjs
@@ -26,17 +30,17 @@ fixjs:  ## run autopep8/tslint fix
 	./node_modules/.bin/tslint --fix src/* src/*/*
 
 fixpy:  ## run autopep8/tslint fix
-	python3.7 -m autopep8 --in-place -r -a -a jupyterfs/
+	${PYTHON} -m autopep8 --in-place -r -a -a jupyterfs/
 
 fix:  ## run autopep8/tslint fix
 	make fixjs
 	make fixpy
 
 annotate: ## MyPy type annotation check
-	python3.7 -m mypy -s jupyterfs
+	${PYTHON} -m mypy -s jupyterfs
 
 annotate_l: ## MyPy type annotation check - count only
-	python3.7 -m mypy -s jupyterfs | wc -l
+	${PYTHON} -m mypy -s jupyterfs | wc -l
 
 clean: ## clean the repository
 	find . -name "__pycache__" | xargs  rm -rf
@@ -46,38 +50,42 @@ clean: ## clean the repository
 	# make -C ./docs clean
 
 dev_install: ## set up the repo for active development
-	python3.7 -m pip install -e .[dev]
-	python3.7 -m jupyter serverextension enable --py jupyterfs
-	jlpm build:integrity
-	python3.7 -m jupyter labextension link .
+	${PIP} install -e .[dev]
+	${PYTHON} -m jupyter serverextension enable --py jupyterfs
+	${YARN} build:integrity
+	${PYTHON} -m jupyter labextension link .
 	# verify
-	python3.7 -m jupyter serverextension list
-	python3.7 -m jupyter labextension list
+	${PYTHON} -m jupyter serverextension list
+	${PYTHON} -m jupyter labextension list
 
 docs:  ## make documentation
 	make -C ./docs html
 	open ./docs/_build/html/index.html
 
 install:  ## install to site-packages
-	python3.7 -m pip install .
+	${PIP} install .
 
 serverextension: install ## enable serverextension
-	python3.7 -m jupyter serverextension enable --py jupyterfs
+	${PYTHON} -m jupyter serverextension enable --py jupyterfs
 
 js:  ## build javascript
-	yarn
-	yarn build
+	${YARN} build:integrity
 
 labextension: js ## enable labextension
-	python3.7 -m jupyter labextension install .
+	${PYTHON} -m jupyter labextension install .
 
-dist: js  ## create dists
-	rm -rf dist build
-	python3.7 setup.py sdist bdist_wheel
+dist: ## create dists
+	rm -rf lib tsconfig.tsbuildinfo *junit.xml coverage* .jupyter build dist MANIFEST jupyterfs/labdist node_modules
+	${YARN} build:integrity
+	${PYTHON} setup.py sdist bdist_wheel
 
 publish: dist  ## dist to pypi and npm
 	twine check dist/* && twine upload dist/*
 	npm publish
+
+publishdry: dist  ## dry-run dist to pypi and npm
+	twine check dist/*
+	npm publish --dry-run
 
 # Thanks to Francoise at marmelab.com for this
 .DEFAULT_GOAL := help

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ parameters:
     - script: yarn install
       displayName: 'Install Javascript lint deps'
 
-    - script: make lintjs
+    - script: make lintjs YARN=yarn
       displayName: 'Lint JS'
 
     - bash: pip install flake8
@@ -127,7 +127,7 @@ parameters:
     - script: yarn install && yarn build
       displayName: 'Build the labextension'
 
-    - script: make testjs
+    - script: make testjs YARN=yarn
       displayName: 'Run the Jest tests'
 
 - name: testBrowserSteps

--- a/jupyterfs/__init__.py
+++ b/jupyterfs/__init__.py
@@ -13,3 +13,69 @@ def _jupyter_server_extension_paths():
     return [{
         "module": "jupyterfs.extension"
     }]
+
+# monkey patch that applies diff from PR:
+# https://github.com/althonos/fs.smbfs/pull/11
+from fs.permissions import Permissions
+from fs.smbfs import SMBFS
+import smb
+
+@classmethod
+def _make_access_from_sd(cls, sd):
+    """Translate a `SecurityDescriptor` object to a raw access `dict`.
+    Arguments:
+        sd (smb.security_descriptors.SecurityDescriptor): the security
+            descriptors obtained through SMB.
+    Note:
+        Since Windows (and as such, SMB) do not handle the permissions the
+        way UNIX does, the permissions here are translated as such:
+            * ``user`` mode is taken from the *read* / *write* / *execute*
+                access descriptors of the user owning the resource.
+            * ``group`` mode is taken from the *read* / *write* / *execute*
+                access descriptors of the group owning the resource.
+            * ``other`` mode uses the permissions of the **Everyone** group,
+                which means sometimes an user could be denied access to a
+                file Windows technically allows to open (since there is no
+                such thing as *other* groups in Windows).
+    """
+    access = {'gid': str(sd.group), 'uid': str(sd.owner)}
+
+    # Extract Access Control Entries corresponding to
+    # * `everyone` (used for UNIX `others` mode)
+    # * `owner` (used for UNIX `user` mode, falls back to `everyone`)
+    # * `group` (used for UNIX `group` mode, falls back to `everyone`)
+    other_ace = next((ace for ace in sd.dacl.aces
+        if str(ace.sid).startswith(smb.security_descriptors.SID_EVERYONE)), None)
+    owner_ace = next((ace for ace in sd.dacl.aces
+        if str(ace.sid).startswith(str(sd.owner))), other_ace)
+    group_ace = next((ace for ace in sd.dacl.aces
+        if str(ace.sid).startswith(str(sd.group))), other_ace)
+
+    # Defines the masks used to check for the attributes
+    attributes = {
+        'r': smb.smb_constants.FILE_READ_DATA \
+            & smb.smb_constants.FILE_READ_ATTRIBUTES,
+        'w': smb.smb_constants.FILE_WRITE_DATA \
+            & smb.smb_constants.FILE_WRITE_ATTRIBUTES,
+        'x': smb.smb_constants.FILE_EXECUTE,
+    }
+
+    # Defines the mask used for each mode
+    other_mask = other_ace.mask if other_ace is not None else 0x0
+    modes = {
+        'u': (owner_ace.mask if owner_ace is not None else 0x0) | other_mask,
+        'g': (group_ace.mask if group_ace is not None else 0x0) | other_mask,
+        'o': other_mask,
+    }
+
+    # Create the permissions from a permission list
+    access['permissions'] = Permissions([
+        '{}_{}'.format(mode_name, attr_name)
+            for mode_name, mode_mask in modes.items()
+                for attr_name, attr_mask in attributes.items()
+                    if attr_mask & mode_mask
+    ])
+
+    return access
+
+SMBFS._make_access_from_sd = _make_access_from_sd

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest": "^25.2.3",
     "jest-raw-loader": "^1.0.1",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.3",
+    "rimraf": "^2.7.1",
     "ts-jest": "~25.2.1",
     "tslint": "^5.20.0",
     "typescript": "^3.7.0"

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,12 @@ cmdclass.pop('develop')
 requires = [
     'fs>=2.4.11',
     'fs-s3fs>=1.1.1',
-    'fs.smbfs @ git+https://github.com/telamonian/fs.smbfs.git@dont_assume_everyone_ace_exists#egg=fs.smbfs',
+    'fs.smbfs>=0.6.1',
     'jupyterlab>=2.0.0',
     'notebook>=5.7.0',
+
+    # remove when fs.smbfs monkey patch is removed
+    'pysmb>=1.1.28',
 ]
 
 test_requires = [


### PR DESCRIPTION
fixes #32

Haven't head back from @althonos about althonos/fs.smbfs#11, so I'm going to go ahead and publish 0.0.2 using a workaround. Not the prettiest solution in the world, but probably the simplest. Pull in the real `fs.smbfs` in setup.py and then applies the diff from my PR as a monkeypatch.

Once this gets pulled in we'll be able to actually complete the release of 0.0.2 to pypi (I already did [a release to test pypi](https://test.pypi.org/project/jupyter-fs/) and it went through perfectly).