### PR TITLE
Update fs.smbfs to 0.6.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ parameters:
     - script: yarn install
       displayName: 'Install Javascript lint deps'
 
-    - script: make lintjs
+    - script: make lintjs YARN=yarn
       displayName: 'Lint JS'
 
     - bash: pip install flake8
@@ -127,7 +127,7 @@ parameters:
     - script: yarn install && yarn build
       displayName: 'Build the labextension'
 
-    - script: make testjs
+    - script: make testjs YARN=yarn
       displayName: 'Run the Jest tests'
 
 - name: testBrowserSteps

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest": "^25.2.3",
     "jest-raw-loader": "^1.0.1",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.3",
+    "rimraf": "^2.7.1",
     "ts-jest": "~25.2.1",
     "tslint": "^5.20.0",
     "typescript": "^3.7.0"

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ cmdclass.pop('develop')
 requires = [
     'fs>=2.4.11',
     'fs-s3fs>=1.1.1',
-    'fs.smbfs @ git+https://github.com/telamonian/fs.smbfs.git@dont_assume_everyone_ace_exists#egg=fs.smbfs',
+    'fs.smbfs>=0.6.2',
     'jupyterlab>=2.0.0',
     'notebook>=5.7.0',
 ]


### PR DESCRIPTION
This PR updates setup.py to point to the latest release (`fs.smbfs@0.6.2`). Previously, setup.py pointed to my [PR branch](https://github.com/telamonian/fs.smbfs/tree/dont_assume_everyone_ace_exists) of fs.smbfs.

There's also some minor buildsystem tweaks. Once this PR gets pulled in, I should be able to immediately do the 0.0.2 release