### PR TITLE
Bump version: 0, 0, 2, 'final', 0 → 0, 0, 3, 'final', 0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0, 0, 2, 'final', 0
+current_version = 0, 0, 3, 'final', 0
 commit = True
 tag = False
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
@@ -17,7 +17,7 @@ values =
 
 [bumpversion:file:jupyterfs/_version.py]
 
-[bumpversion:file:package.json]
+[bumpversion:file:js/package.json]
 search = "version": "{current_version}"
 replace = "version": "{new_version}"
 serialize = 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-fs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A Filesystem-like mult-contents manager backend for Jupyter",
   "author": "The jupyter-fs authors",
   "license": "Apache-2.0",

--- a/jupyterfs/_version.py
+++ b/jupyterfs/_version.py
@@ -12,7 +12,7 @@ VersionInfo = namedtuple('VersionInfo', [
 ])
 
 # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
-version_info = VersionInfo(0, 0, 2, 'final', 0)
+version_info = VersionInfo(0, 0, 3, 'final', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
bumps master to 0.0.3, to match the latest release/tag. also includes a small fix to account for the `package.json` -> `js/package.json` move