### PR TITLE
fixed up server-side config of filesystem resources via the `jupyterfs.resources` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install jupyter-fs
 
 Add the following to your `jupyter_notebook_config.json`:
 
-```
+```json
 {
   "NotebookApp": {
     "contents_manager_class": "jupyterfs.metamanager.MetaManager",
@@ -118,10 +118,10 @@ The `"url"` field jupyter-fs config is based on the PyFilesystem [opener url](ht
 
 ## Server-side settings
 
-If you prefer to set up your filesystem resources in the server-side config, you can do so. For example, you can set up a local filesystem by adding the following to your `jupyter_notebook_config.py`:
+If you prefer to set up your filesystem resources in the server-side config, you can do so. For example, you can set up a local filesystem by adding the following to your `jupyter_notebook_config.py` file:
 
 ```python
-c.jupyterfs.specs = [
+c.jupyterfs.resources = [
     {
         "name": "local_test",
         "url": "osfs:///Users/foo/test"
@@ -129,7 +129,28 @@ c.jupyterfs.specs = [
 ]
 ```
 
-Any filesystem specs given in the server-side config will be merged with the specs given in a user's settings.
+ALternatively, you can add resource specifications alongside the basic jupyter-fs config in your `jupyter_notebook_config.json` file:
+
+```json
+{
+  "NotebookApp": {
+    "contents_manager_class": "jupyterfs.metamanager.MetaManager",
+    "nbserver_extensions": {
+      "jupyterfs.extension": true
+    }
+  },
+  "jupyterfs": {
+    "resources": [
+      {
+        "name": "local_test",
+        "url": "osfs:///Users/foo/test"
+      },
+    ]
+  }
+}
+```
+
+Any filesystem resources specified in any server-side config file will be merged with the resources given in a user's settings.
 
 
 ## Development

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+- `0.0.4`
+  - Full support for server side config
+    - Can be used with/without frontend config and/or auth
+  - Fixed settings icon
+
+- `0.0.3`
+  - Added support for auth
+    - Username/password and/or other credentials can be manually queried via a dialog box, or determined from the user's environment variables

--- a/js/schema/plugin.json
+++ b/js/schema/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "jupyter-fs",
   "description": "Settings for the jupyter-fs extension.",
-  "jupyter.lab.setting-icon": "fs:drive",
-  "jupyter.lab.setting-icon-label": "fs",
+  "jupyter.lab.setting-icon": "jfs:drive",
+  "jupyter.lab.setting-icon-label": "jupyter-fs",
   "type": "object",
   "additionalProperties": false,
 

--- a/js/src/filesystem.ts
+++ b/js/src/filesystem.ts
@@ -11,6 +11,8 @@ import { URLExt } from "@jupyterlab/coreutils";
 import { ServerConnection } from "@jupyterlab/services";
 
 export interface IFSOptions {
+  _addServerside: boolean;
+
   /**
    * If true, only recreate the actual resource when necessary
    */

--- a/js/src/index.tsx
+++ b/js/src/index.tsx
@@ -88,7 +88,13 @@ async function activate(
 
     // send user specs to backend; await return containing resources
     // defined by user settings + resources defined by server config
-    resources = await comm.initResourceRequest({resources, options});
+    resources = await comm.initResourceRequest({
+      resources,
+      options: {
+        ...options,
+        _addServerside: true,
+      },
+    });
 
     if (askRequired(resources)) {
       // ask for url template values, if required
@@ -102,11 +108,11 @@ async function activate(
 
       const handleSubmit = async (values: {[url: string]: {[key: string]: string}}) => {
         await refreshWidgets({
-          options,
           resources: await comm.initResourceRequest({
-            options,
             resources: resources.map(r => {return {...r, tokenDict: values[r.url]}}),
+            options,
           }),
+          options,
         });
       }
 

--- a/jupyterfs/extension.py
+++ b/jupyterfs/extension.py
@@ -37,7 +37,7 @@ def load_jupyter_server_extension(nb_server_app):
 
     # init managers from resources described in notebook server config
     nb_server_app.contents_manager.initResource(
-        *nb_server_app.config.get('jupyterfs', {}).get('specs', [])
+        *nb_server_app.config.get('jupyterfs', {}).get('resources', [])
     )
 
     resources_url = 'jupyterfs/resources'

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -44,6 +44,10 @@ class MetaManager(ContentsManager):
         managers = dict([self._default_cm])
 
         for resource in resources:
+            # server side resources don't have a default 'auth' key
+            if 'auth' not in resource:
+                resource['auth'] = 'ask'
+
             # get deterministic hash of PyFilesystem url
             _hash = md5(resource['url'].encode('utf-8')).hexdigest()[:8]
             init = False

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -159,7 +159,13 @@ class MetaManagerHandler(APIHandler):
     async def post(self):
         # will be a list of resource dicts
         body = self.get_json_body()
+        options = body['options']
+
+        if '_addServerside' in options and options['_addServerside']:
+            resources = list((*self.config_resources, *body['resources']))
+        else:
+            resources = body['resources']
 
         self.finish(json.dumps(
-            self.contents_manager.initResource(*self.config_resources, *body['resources'], options=body['options'])
+            self.contents_manager.initResource(*resources, options=options)
         ))


### PR DESCRIPTION
In your notebook server settings, the `jupyterfs.resources` key will now take the same json list-of-dicts of filesystem resource specifications as the `resources` key in the jupyter-fs frontend settings