### PR TITLE
set correct permission on AttrbuteError

### DIFF
--- a/jupyterfs/fsmanager.py
+++ b/jupyterfs/fsmanager.py
@@ -210,6 +210,8 @@ class FSManager(FileContentsManager):
         except OSError:
             self.log.error("Failed to check write permissions on %s", path)
             model['writable'] = False
+        except AttributeError:
+            model['writable'] = False
         return model
 
     def _dir_model(self, path, content=True):


### PR DESCRIPTION
This trapped AttributeError which occurs with some pyfilesystem
backends