### PR TITLE
make sure that there is only one entry of file

### DIFF
--- a/js/src/filetree.ts
+++ b/js/src/filetree.ts
@@ -214,9 +214,18 @@ export class FileTree extends Widget {
         };
       }
 
+      let element;
       if (level === 1) {
+        element = this.tree.querySelector("[id='" + tr.id + "']");
+        if (element !== null) {
+          this.tree.removeChild(element);
+        }
         this.tree.appendChild(tr);
       } else {
+        element = parent.parentNode.querySelector("[id='" + tr.id + "']");
+        if (element !== null) {
+          parent.parentNode.removeChild(element);
+        }
         parent.after(tr);
         parent = tr;
       }


### PR DESCRIPTION
This removes old table entries before adding new ones.  Multiple entries
can appear as a result of a race condition in which latency in getting
entries causes multiple entries to appear.