### PR TITLE
Add `defaultWritable` resource argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Add specifications for additional contents managers in your user settings (in th
       "url": "s3://test"
     },
     {
+      "name": "s3 test key",
+      "url": "s3://test-2/prefix/",
+      "defaultWritable": false
+    },
+    {
       "name": "samba guest share",
       "url": "smb://guest@127.0.0.1/test?name-port=3669"
     }

--- a/js/schema/plugin.json
+++ b/js/schema/plugin.json
@@ -26,6 +26,11 @@
           "type": "string",
           "enum": ["ask", "env", false],
           "default": "ask"
+        },
+	"defaultWritable": {
+          "description": "Fallback for determining if resource is writeable. Used only if the underlying PyFilesystem does not provide this information (eg S3)",
+          "type": "boolean",
+          "default": true
         }
       }
     }

--- a/jupyterfs/fsmanager.py
+++ b/jupyterfs/fsmanager.py
@@ -112,7 +112,8 @@ class FSManager(FileContentsManager):
     def init_fs(cls, pyfs_class, *args, **kwargs):
         return cls(pyfs_class(*args, **kwargs))
 
-    def __init__(self, pyfs, *args, **kwargs):
+    def __init__(self, pyfs, *args, default_writable=True, **kwargs):
+        self._default_writable = default_writable
         if isinstance(pyfs, str):
             # pyfs is an opener url
             self._pyfilesystem_instance = open_fs(pyfs, *args, **kwargs)
@@ -204,9 +205,8 @@ class FSManager(FileContentsManager):
         try:
             model['writable'] = info.permissions.check('u_w')  # TODO check
         except (errors.MissingInfoNamespace,):
-            # if relevant namespace is missing, assume writable
-            # TODO: decide if this is wise
-            model['writable'] = True
+            # use default if access namespace is missing
+            model['writable'] = self._default_writable
         except OSError:
             self.log.error("Failed to check write permissions on %s", path)
             model['writable'] = False

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -76,7 +76,12 @@ class MetaManager(ContentsManager):
                     init = False
                 else:
                     # create new cm
-                    managers[_hash] = FSManager(urlSubbed, **self._pyfs_kw)
+                    default_writable = resource.get('defaultWritable', True)
+                    managers[_hash] = FSManager(
+                        urlSubbed,
+                        default_writable=default_writable,
+                        **self._pyfs_kw
+                    )
                     init = True
 
             # assemble resource from spec + hash


### PR DESCRIPTION
If a filesystem doesn't support the `access` namespace for
`getinfo()`, allow the config to specify whether the returned
items should be treated as writeable or not.