### PR TITLE
fixes #64: remove lookbehind from javascript regex

### DIFF
--- a/js/src/auth.tsx
+++ b/js/src/auth.tsx
@@ -36,12 +36,17 @@ class Template {
   }
 
   tokens() {
-    return this.template.match(this.pattern) || [];
+    let toks = [];
+    let match;
+    while (match = this.pattern.exec(this.template)) {
+      toks.push(match[1]);
+    }
+    return toks;
   }
 }
 
 export class DoubleBraceTemplate extends Template {
-  public pattern = /(?<=\{\{)\w*?(?=\}\})/g;
+  public pattern = /{{(\S+?)}}/g;
 }
 
 function tokensFromUrl(url: string): string[] {

--- a/jupyterfs/auth.py
+++ b/jupyterfs/auth.py
@@ -22,7 +22,7 @@ class BraceTemplate(_BaseTemplate):
     delimiter = ''
     pattern = r'''
     (?:
-      [^{]{(?P<braced>\w*)}[^}]    | # match anything in single braces
+      [^{]{(?P<braced>\S+?)}[^}]    | # match anything in single braces
       (?P<escaped>a^)              | # match nothing
       (?P<named>a^)                | # match nothing
       (?P<invalid>a^)                # match nothing
@@ -36,7 +36,7 @@ class DoubleBraceTemplate(_BaseTemplate):
     delimiter = ''
     pattern = r'''
     (?:
-      {{(?P<braced>\w*)}}    | # match anything in double braces
+      {{(?P<braced>\S+?)}}    | # match anything in double braces
       (?P<escaped>a^)        | # match nothing
       (?P<named>a^)          | # match nothing
       (?P<invalid>a^)          # match nothing

--- a/jupyterfs/extension.py
+++ b/jupyterfs/extension.py
@@ -12,7 +12,7 @@ from notebook.utils import url_path_join
 
 from .metamanager import MetaManagerHandler, MetaManager
 
-_mc_config_warning_msg = """Misconfiguration of MetaManager. Please add:
+_mm_config_warning_msg = """Misconfiguration of MetaManager. Please add:
 
 "NotebookApp": {
   "contents_manager_class": "jupyterfs.metamanager.MetaManager"
@@ -32,7 +32,7 @@ def load_jupyter_server_extension(nb_server_app):
     host_pattern = '.*$'
 
     if not isinstance(nb_server_app.contents_manager, MetaManager):
-        warnings.warn(_mc_config_warning_msg)
+        warnings.warn(_mm_config_warning_msg)
         return
 
     # init managers from resources described in notebook server config


### PR DESCRIPTION
fixes #64

Replaces the lookbehind regex mentioned in #64 with a simpler regex without one. Also makes some needed changes to the `match` code that uses said regex