### PR TITLE
added `yarn-deduplicate` step to `build:integrity` cmd

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,15 +9,13 @@ include .bumpversion.cfg
 include Makefile
 
 include jupyterfs/chrome-test.js
-graft jupyterfs/tests
 
 # Webapp files
 graft js
-prune js/dist
 prune js/build
+prune js/dist
 prune js/lib
 prune js/node_modules
-prune js/yarn.lock
 
 # Patterns to exclude from any directory
 global-exclude *~
@@ -25,3 +23,5 @@ global-exclude *.pyc
 global-exclude *.pyo
 global-exclude .git
 global-exclude .ipynb_checkpoints
+global-exclude tsconfig.tsbuildinfo
+global-exclude yarn.lock

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ PIP := pip
 PYTHON := python
 YARN := jlpm
 
-testjs: ## Clean and Make js tests
+testjs: ## Make js tests
 	cd js; ${YARN} test
 
-testpy: ## Clean and Make py tests
+testpy: ## Make py tests
 	${PYTHON} -m pytest -v jupyterfs/tests --cov=jupyterfs --cov-branch --junitxml=python_junit.xml --cov-report=xml
 
 testbrowser:
@@ -46,8 +46,8 @@ clean: ## clean the repository
 	find . -name "__pycache__" | xargs  rm -rf
 	find . -name "*.pyc" | xargs rm -rf
 	find . -name ".ipynb_checkpoints" | xargs  rm -rf
-	rm -rf build coverage* dist *.egg-info *junit.xml .jupyter MANIFEST node_modules
-	rm -rf js/dist js/lib js/node_modules js/tsconfig.tsbuildinfo
+	rm -rf build coverage* dist *.egg-info *junit.xml .jupyter MANIFEST node_modules package-lock.json pip-wheel-metadata yarn.lock
+	rm -rf js/dist js/lib js/node_modules js/package-lock.json js/tsconfig.tsbuildinfo js/yarn.lock
 	rm -rf jupyterfs/labdist
 	# make -C ./docs clean
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,7 @@ parameters:
 - name: testJavascriptSteps
   type: stepList
   default:
-    - script: cd js; yarn install && yarn build
+    - script: make js YARN=yarn
       displayName: 'Build the labextension'
 
     - script: make testjs YARN=yarn

--- a/js/package.json
+++ b/js/package.json
@@ -14,15 +14,18 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:integrity": "jlpm install && jlpm build",
-    "build:labdist": "jlpm build:integrity && jlpm clean:labdist && mkdirp ../jupyterfs/labdist && cd ../jupyterfs/labdist && npm pack ../../js",
+    "build:integrity": "yarn install && yarn deduplicate && yarn install && yarn build",
+    "build:labdist": "yarn build:integrity && yarn clean:labdist && mkdirp ../jupyterfs/labdist && cd ../jupyterfs/labdist && npm pack ../../js",
     "clean": "rimraf lib tsconfig.tsbuildinfo *junit.xml coverage* .jupyter",
-    "clean:more": "jlpm clean && rimraf build dist MANIFEST",
+    "clean:more": "yarn clean && rimraf build dist MANIFEST",
     "clean:labdist": "rimraf ../jupyterfs/labdist",
-    "clean:slate": "jlpm clean:more && jlpm clean:labdist && rimraf ../node_modules",
+    "clean:slate": "yarn clean:more && yarn clean:labdist && rimraf ../node_modules",
+    "deduplicate": "yarn yarn-deduplicate -s fewer ../yarn.lock || yarn yarn-deduplicate -s fewer",
     "fix": "eslint -c .eslintrc.js --ext .js,.ts --fix .",
     "lint": "eslint -c .eslintrc.js --ext .js,.ts .",
-    "prepublishOnly": "jlpm run build",
+    "postpack": "shx rm README.md",
+    "prepack": "shx cp ../README.md .",
+    "prepublishOnly": "yarn run build",
     "test": "jest --coverage --collectCoverageFrom=src/*.{ts,tsx}",
     "test:browser": "../ci/browser_check.sh",
     "watch": "tsc -w"
@@ -88,7 +91,9 @@
     "jest-raw-loader": "^1.0.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.7.1",
+    "shx": "^0.3.3",
     "ts-jest": "~25.2.1",
-    "typescript": "^3.9.0"
+    "typescript": "^3.9.0",
+    "yarn-deduplicate": "^3.1.0"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     ],
     cmdclass=cmdclass,
     keywords='jupyter jupyterlab',
-    packages=find_packages(exclude=['tests', ]),
+    packages=find_packages(exclude=('js', 'js.*')),
     install_requires=requires,
     extras_require={
         'dev': dev_requires


### PR DESCRIPTION
fixes #67

Adds `yarn-deduplicate` step to `build:integrity` cmd. Also some related small build fixes.