### PR TITLE
add general support for binder and an action that creates a new binder on PR creation

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,0 +1,26 @@
+# Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
+name: Binder Badge
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    steps:
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v1
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
+          var PR_HEAD_REF = process.env.PR_HEAD_REF;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab) Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+          })
+      env:
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,16 @@
+# a mybinder.org-ready environment for demoing jupyter-fs
+# this environment may also be used locally on Linux/MacOS/Windows, e.g.
+#
+#   conda env update --file binder/environment.yml
+#   conda activate jupyter-fs-demo
+#
+name: jupyter-fs-demo
+
+channels:
+  - conda-forge
+dependencies:
+  - python >=3.8,<3.9.0a0
+  - jupyterlab >=3,<4.0.0a0
+  - nodejs=15.8
+  - pip
+  - wheel

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,13 @@
+#!/bin/bash
+mkdir -p /tmp/yarn
+export YARN_CACHE_FOLDER="/tmp/yarn"
+
+python --version
+
+jupyter lab clean --all
+
+pip install .[dev]
+
+jupyter --version
+
+jupyter lab build --debug


### PR DESCRIPTION
It appears that the action that creates the comment with a binder link won't actually fire until the relevant workflow script is commited and the *next* PR is then opened. Since I can't really debug this until said next PR, I'm just going to pull this in as-is and iterate