### PR TITLE
Bump version: 0.3.0final0 → 0.3.1final0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0final0
+current_version = 0.3.1final0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-fs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Filesystem-like mult-contents manager backend for Jupyter",
   "author": "The jupyter-fs authors",
   "license": "Apache-2.0",

--- a/jupyterfs/_version.py
+++ b/jupyterfs/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'


### PR DESCRIPTION
First release that includes a prebuilt labextension! Wooo!