### PR TITLE
Change when to initial setup

### DIFF
--- a/js/src/index.tsx
+++ b/js/src/index.tsx
@@ -132,8 +132,8 @@ async function activate(
   }
 
   if (settings) {
-    // initial setup
-    void refresh();
+    // initial setup when DOM attachment of custom elements is complete.
+    app.started.then(refresh);
 
     // rerun setup whenever relevant settings change
     // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/js/src/index.tsx
+++ b/js/src/index.tsx
@@ -133,7 +133,7 @@ async function activate(
 
   if (settings) {
     // initial setup when DOM attachment of custom elements is complete.
-    app.started.then(refresh);
+    void app.started.then(refresh);
 
     // rerun setup whenever relevant settings change
     // eslint-disable-next-line @typescript-eslint/no-misused-promises


### PR DESCRIPTION
## References
Fixes #129, #76

## Code changes
Changed when to initial setup.

I wrote details in #129, but the summary of the reason for the change are shown below.

### Summary
The  bug of #129 is caused by the following reasons

    When JupyterLab starts up, `jupyter-fs's refresh()` being executed before `regular-table's connectedCallback()` is executed.
    However, that does not complete the necessary initialization and generates a null reference.

After `application's start()` is completed, `connectedCallback()` has already been executed.

Therefore, I changed it so that `refresh()` is executed at that timing.

## User-facing changes
None

## Backwards-incompatible changes
None
