### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  pull-requests:
+    write
+
 jobs:
   binder:
     runs-on: ubuntu-latest

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Vidar Tonaas Fauske
 Chris Ball
 lsowen
 ManthanKeim
+Reo Ono

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,24 @@ install:
 - bash -c "sleep 5"
 - curl http://127.0.0.1:9000/
 
+# install rust and winpty for pywinpty (one of python deps)
+# refs: https://pypi.org/project/pywinpty/
+# install rust
+- appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+- rustup-init -y --default-toolchain stable --default-host i686-pc-windows-msvc
+- set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+# install winpty
+- curl -#Lo winpty-native.zip "https://github.com/rprichard/winpty/releases/download/0.4.2/winpty-0.4.2-msvc2015.zip"
+- call 7z e -y -o"winpty\x86\bin" winpty-native.zip "ia32\bin\winpty.dll" > nul
+- call 7z e -y -o"winpty\x86\bin" winpty-native.zip "ia32\bin\winpty-agent.exe" > nul
+- call 7z e -y -o"winpty\x86\bin" winpty-native.zip "ia32\bin\winpty-debugserver.exe" > nul
+- call 7z e -y -o"winpty\x86\lib" winpty-native.zip "ia32\lib\winpty.lib" > nul
+- call 7z e -y -o"winpty\include" winpty-native.zip "include\winpty.h" > nul
+- call 7z e -y -o"winpty\include" winpty-native.zip "include\winpty_constants.h" > nul
+- set PATH=%CD%\winpty\x86\bin;%PATH%
+- set LIB=%CD%\winpty\x86\lib;%LIB%
+- set INCLUDE=%CD%\winpty\include;%INCLUDE%
+
 # install python deps
 - pip install --upgrade -e .[dev] -v
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ jobs:
 
 - job: 'python__mac'
   pool:
-    vmImage: 'macos-10.14'
+    vmImage: 'macOS-latest'
   variables:
     python.version: '3.7'
 
@@ -235,7 +235,7 @@ jobs:
 # TODO: delete this duplicate job, once the required test has been renamed on github: "Mac Python37" => "python__mac"
 - job: 'Mac'
   pool:
-    vmImage: 'macos-10.14'
+    vmImage: 'macOS-latest'
   strategy:
     matrix:
       Python37:

--- a/ci/install_docker_desktop_mac.sh
+++ b/ci/install_docker_desktop_mac.sh
@@ -1,52 +1,7 @@
 #!/usr/bin/env bash
 
 # refs:
-# https://github.com/MicrosoftDocs/vsts-docs/issues/3784
-# https://forums.docker.com/t/docker-for-mac-unattended-installation/27112
+# https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
 
 brew install --cask docker
-# allow the app to run without confirmation
-xattr -d -r com.apple.quarantine /Applications/Docker.app
-
-# preemptively do docker.app's setup to avoid any gui prompts
-sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
-
-# the plist we need used to be in /Applications/Docker.app/Contents/Resources, but
-# is now dynamically generated. So we dynamically generate our own
-sudo tee "/Library/LaunchDaemons/com.docker.vmnetd.plist" > /dev/null <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>Label</key>
-	<string>com.docker.vmnetd</string>
-	<key>Program</key>
-	<string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
-	</array>
-	<key>RunAtLoad</key>
-	<true/>
-	<key>Sockets</key>
-	<dict>
-		<key>Listener</key>
-		<dict>
-			<key>SockPathMode</key>
-			<integer>438</integer>
-			<key>SockPathName</key>
-			<string>/var/run/com.docker.vmnetd.sock</string>
-		</dict>
-	</dict>
-	<key>Version</key>
-	<string>59</string>
-</dict>
-</plist>
-
-EOF
-
-sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
-sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
-sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
-
-sleep 5
+sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components

--- a/ci/start_docker_desktop_mac.sh
+++ b/ci/start_docker_desktop_mac.sh
@@ -1,40 +1,9 @@
 #!/usr/bin/env bash
 
 # refs:
-# https://stackoverflow.com/a/35979292
-# https://crossprogramming.com/2019/12/27/use-docker-when-running-integration-tests-with-azure-pipelines.html#self-managed-docker-containers
+# https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
 
-[[ $(uname) == 'Darwin' ]] || { echo "This function only runs on macOS." >&2; exit 2; }
-
-# show if Docker.app is present
-set -x
-ls /Applications
-set +x
-
-printf "\nStarting Docker.app, if necessary"
-
-# Wait for the server to start up, if applicable.
-retries=0
-while ! docker system info &>/dev/null; do
-    if (( retries % 30 == 0 )); then
-        if pgrep -xq -- "Docker"; then
-            printf '\nDocker init still running'
-        else
-            (( retries != 0 )) && printf '\nDocker not running, restart'
-            # /Applications/Docker.app/Contents/MacOS/Docker &
-            open -g -a Docker.app || exit
-        fi
-
-        if [[ ${retries} -gt 600 ]]; then
-            printf '\nFailed to run Docker'
-            exit 1
-        fi
-    fi
-
-    printf '.'
-    (( retries++))
-    sleep 1
-done
-(( retries )) && printf '\n'
+open -a /Applications/Docker.app --args --unattended --accept-license
+while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
 
 echo "Docker is ready"

--- a/jupyterfs/tests/test_fsmanager.py
+++ b/jupyterfs/tests/test_fsmanager.py
@@ -222,7 +222,7 @@ class Test_FSManager_smb_os_share(_TestBase):
         kwargs = dict(
             direct_tcp=test_direct_tcp_smb_os_share,
             host=test_host_smb_os_share,
-            hostname=socket.getfqdn(),
+            hostname=socket.gethostname(),
             passwd=samba.smb_passwd,
             share=test_dir,
             username=samba.smb_user,

--- a/jupyterfs/tests/utils/samba.py
+++ b/jupyterfs/tests/utils/samba.py
@@ -92,7 +92,7 @@ class RootDirUtil:
         smb_port=None
     ):
         self.host = socket.gethostbyname(socket.gethostname()) if host is None else host
-        self.hostname = socket.getfqdn() if hostname is None else hostname
+        self.hostname = socket.gethostname() if hostname is None else hostname
 
         self.dir_name = dir_name
         self.direct_tcp = direct_tcp


### PR DESCRIPTION
## References
Fixes https://github.com/jpmorganchase/jupyter-fs/issues/121

## Summary
### Binder Badge
After checking the official Binder documentation, I found that the permissions were not set properly.
The format was referred to the `ipywidget` repository.
https://github.com/jupyter-widgets/ipywidgets/blob/88cec8be2869e75760a6a99bba129e6011d9043f/.github/workflows/binder-on-pr.yml#L7

### Azure Pipeline
macOS-10.14 images were no longer available. Therefore, I modified it to use the latest image.
https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

However, the new image was failing to install Docker, so I corrected the relevant step based on the following comment.
https://github.com/docker/for-mac/issues/2359#issuecomment-943131345

### Appveyor
The installation of `pywinpty` was failing due to a newer version of Python. Therefore, the necessary dependencies were added to the installation.

Also, when the installation error was resolved, `NotConnected` error occurred in Test_FSManager_smb_os_share.
While verifying with RDP, in the following URI, the hostname was `appveyor-vm.appveyor.local`.
```
 uri = 'smb://{username}:{passwd}@{host}:{port}/{share}?hostname={hostname}&direct-tcp={direct_tcp}'
```
When I corrected hostname to `appveyor` , the connection was established.
So I modified to use gethostname() instead of getfqdn().
