### PR TITLE
remove deprecated methods

### DIFF
--- a/jupyterfs/config.py
+++ b/jupyterfs/config.py
@@ -7,7 +7,7 @@
 #
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.services.contents.manager import ContentsManager
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 from traitlets import List, Type
 from traitlets.config import Configurable
 
@@ -17,13 +17,13 @@ class Jupyterfs(Configurable):
     root_manager_class = Type(
         config=True,
         default_value=LargeFileManager,
-        help=_("the root contents manager class to use. Used by the Jupyterlab default filebrowser and elsewhere"),
+        help=_i18n("the root contents manager class to use. Used by the Jupyterlab default filebrowser and elsewhere"),
         klass=ContentsManager,
     )
 
     resources = List(
         config=True,
         default_value=[],
-        help=_("server-side definitions of fsspec resources for jupyter-fs"),
+        help=_i18n("server-side definitions of fsspec resources for jupyter-fs"),
         # trait=Dict(traits={"name": Unicode, "url": Unicode}),
     )

--- a/jupyterfs/fsmanager.py
+++ b/jupyterfs/fsmanager.py
@@ -406,7 +406,7 @@ class FSManager(FileContentsManager):
             raise web.HTTPError(400, u'No file content provided')
 
         self.log.debug("Saving %s", path)
-        self.run_pre_save_hook(model=model, path=path)
+        self.run_pre_save_hooks(model=model, path=path)
 
         try:
             if model['type'] == 'notebook':
@@ -440,7 +440,7 @@ class FSManager(FileContentsManager):
         if validation_message:
             model['message'] = validation_message
 
-        self.run_post_save_hook(model=model, os_path=path)
+        self.run_post_save_hooks(model=model, os_path=path)
 
         return model
 


### PR DESCRIPTION
## References
Fixes https://github.com/jpmorganchase/jupyter-fs/issues/136

## Summary
Modified to use alternative methods instead of the deprecated methods.

Alternative methods are described in the warning messages.
- [run_pre_save_hook()](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/services/contents/manager.py#L170)
- [run_post_save_hook()](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/services/contents/manager.py#L190)
- [_()](https://github.com/jupyter-server/jupyter_server/blob/3e1ba01efda57627fd6f2f75afa869dc6df4f3b7/jupyter_server/transutils.py#L9)