### PR TITLE
Add rename action

### DIFF
--- a/js/src/treefinder.ts
+++ b/js/src/treefinder.ts
@@ -419,7 +419,7 @@ export namespace TreeFinderSidebar {
           const oldContent = widget.treefinder.selection[0];
           void _doRename(widget, oldContent).then(newContent => {
             widget.treefinder.model.renamerSub.next( { name: newContent.name, target: oldContent } );
-            // TODO
+            // TODO: Model state of TreeFinderWidget should be updated by renamerSub process.
             oldContent.row = newContent;
           });
         },

--- a/js/src/treefinder.ts
+++ b/js/src/treefinder.ts
@@ -9,12 +9,13 @@
 import { ILayoutRestorer, IRouter, JupyterFrontEnd } from "@jupyterlab/application";
 import {
   IWindowResolver,
+  showErrorMessage,
   Toolbar,
   ToolbarButton,
-  WidgetTracker, /*Clipboard, Dialog, IWindowResolver, showDialog, showErrorMessage*/
+  WidgetTracker, /*Clipboard, Dialog, IWindowResolver, showDialog*/
 } from "@jupyterlab/apputils";
 // import { PathExt, URLExt } from "@jupyterlab/coreutils";
-import { IDocumentManager /*isValidFileName, renameFile*/ } from "@jupyterlab/docmanager";
+import { IDocumentManager, isValidFileName /*renameFile*/ } from "@jupyterlab/docmanager";
 // import { DocumentRegistry } from "@jupyterlab/docregistry";
 import { Contents, ContentsManager } from "@jupyterlab/services";
 import {
@@ -28,11 +29,12 @@ import {
 // import JSZip from "jszip";
 import { DisposableSet, IDisposable } from "@lumino/disposable";
 import { PanelLayout, Widget } from "@lumino/widgets";
-import { Format, IContentRow, Path, TreeFinderPanelElement } from "tree-finder";
+import { Content, Format, IContentRow, Path, TreeFinderPanelElement } from "tree-finder";
 
 import { JupyterClipboard } from "./clipboard";
 import { IFSResource } from "./filesystem";
 import { fileTreeIcon } from "./icons";
+import { doRename } from "./utils";
 // import { Uploader } from "./upload";
 
 export class JupyterContents {
@@ -44,6 +46,12 @@ export class JupyterContents {
   async get(path: string) {
     path = JupyterContents.toFullPath(path, this.drive);
     return JupyterContents.toJupyterContentRow(await this.cm.get(path), this.cm, this.drive);
+  }
+
+  async rename(path: string, newPath: string) {
+    path = JupyterContents.toFullPath(path, this.drive);
+    newPath = JupyterContents.toFullPath(newPath, this.drive);
+    return JupyterContents.toJupyterContentRow(await this.cm.rename(path, newPath), this.cm, this.drive);
   }
 
   readonly cm: ContentsManager;
@@ -407,7 +415,14 @@ export namespace TreeFinderSidebar {
         label: "Paste",
       }),
       app.commands.addCommand(widget.commandIDs.rename, {
-        execute: () => {},
+        execute: args => {
+          const oldContent = widget.treefinder.selection[0];
+          void _doRename(widget, oldContent).then(newContent => {
+            widget.treefinder.model.renamerSub.next( { name: newContent.name, target: oldContent } );
+            // TODO
+            oldContent.row = newContent;
+          });
+        },
         icon: editIcon,
         label: "Rename",
       }),
@@ -462,5 +477,43 @@ export namespace TreeFinderSidebar {
     ].reduce((set: DisposableSet, d) => {
       set.add(d); return set;
     }, new DisposableSet());
+  }
+
+  export function _doRename(widget: TreeFinderSidebar, oldContent: Content<JupyterContents.IJupyterContentRow>): Promise<JupyterContents.IJupyterContentRow> {
+    const textNode = document.querySelector(".tf-mod-select .rt-tree-container .rt-group-name").firstChild as HTMLElement;
+    const original = textNode.textContent;
+    const editNode = document.createElement("input");
+    editNode.value = original;
+    return doRename(textNode, editNode, original).then(
+      newName => {
+        if (!newName || newName === oldContent.name) {
+          return oldContent.row;
+        }
+        if (!isValidFileName(newName)) {
+          void showErrorMessage(
+            "Rename Error",
+            Error(newName +' is not a valid name for a file. Names must have nonzero length, and cannot include "/", "\\", or ":"')
+          );
+          return oldContent.row;
+        }
+        const oldPath = oldContent.getPathAtDepth(1).join("/");
+        const newPath = oldPath.slice(0, -1 * original.length) + newName;
+        const promise = widget.treefinder.cm.rename(oldPath, newPath);
+        return promise
+          .catch(error => {
+            if (error !== "File not renamed") {
+              void showErrorMessage(
+                "Rename Error",
+                error
+              );
+            }
+            return oldContent.row;
+          })
+          .then(newContent => {
+            textNode.textContent = newName;
+            return newContent;
+          });
+      }
+    );
   }
 }

--- a/js/src/treefinder.ts
+++ b/js/src/treefinder.ts
@@ -21,6 +21,7 @@ import {
   closeIcon,
   copyIcon,
   cutIcon,
+  editIcon,
   pasteIcon,
   refreshIcon,
 } from "@jupyterlab/ui-components";
@@ -405,6 +406,11 @@ export namespace TreeFinderSidebar {
         icon: pasteIcon,
         label: "Paste",
       }),
+      app.commands.addCommand(widget.commandIDs.rename, {
+        execute: () => {},
+        icon: editIcon,
+        label: "Rename",
+      }),
       app.commands.addCommand(widget.commandIDs.refresh, {
         execute: args => args["selection"] ? clipboard.refreshSelection(widget.treefinder.model) : clipboard.refresh(widget.treefinder.model),
         icon: refreshIcon,
@@ -437,6 +443,11 @@ export namespace TreeFinderSidebar {
         command: widget.commandIDs.delete,
         selector,
         rank: 5,
+      }),
+      app.contextMenu.addItem({
+        command: widget.commandIDs.rename,
+        selector,
+        rank: 6,
       }),
 
       app.contextMenu.addItem({

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -66,17 +66,21 @@ export function createOpenNode(): HTMLElement {
   return body;
 }
 
-export function doRename(text: HTMLElement, edit: HTMLInputElement) {
-  const parent = text.parentElement;
+export function doRename(
+  text: HTMLElement,
+  edit: HTMLInputElement,
+  original: string
+): Promise<string> {
+  const parent = text.parentElement as HTMLElement;
   parent.replaceChild(edit, text);
   edit.focus();
-  const index = edit.value.lastIndexOf(".");
+  const index = edit.value.lastIndexOf('.');
   if (index === -1) {
     edit.setSelectionRange(0, edit.value.length);
   } else {
     edit.setSelectionRange(0, index);
   }
-  // handle enter
+
   return new Promise<string>((resolve, reject) => {
     edit.onblur = () => {
       parent.replaceChild(text, edit);
@@ -92,6 +96,7 @@ export function doRename(text: HTMLElement, edit: HTMLInputElement) {
         case 27: // Escape
           event.stopPropagation();
           event.preventDefault();
+          edit.value = original;
           edit.blur();
           break;
         case 38: // Up arrow


### PR DESCRIPTION
## References
Relates to https://github.com/telamonian/tree-finder/issues/51

## Summary
Implemented `Rename` function in the right-click menu. Please review and confirm the operation in the binder.

Please note the following points.
- The implementation of the edit box and function names is based on `jupyterlab`'s [default file browser](https://github.com/jupyterlab/jupyterlab/blob/95fc6e74a21953c44a17a73c3d6741ac66320979/packages/filebrowser/src/listing.ts#L1505).
- As mentioned in the comments, `tree-finder`'s renamerSub is not yet functional, so the model update inside `tree-finder` is also done by `jupyter-fs`.
