### PR TITLE
Replace os.path with fs.path in fsmanager.py

### DIFF
--- a/jupyterfs/fsmanager.py
+++ b/jupyterfs/fsmanager.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from fs import errors, open_fs
 from fs.base import FS
 import mimetypes
-import os.path
+import fs.path
 from tornado import web
 
 import nbformat
@@ -239,7 +239,7 @@ class FSManager(FileContentsManager):
         if content:
             model["content"] = contents = []
             for name in self._pyfilesystem_instance.listdir(path):
-                os_path = os.path.join(path, name)
+                os_path = fs.path.join(path, name)
                 if (
                     not self._pyfilesystem_instance.islink(os_path)
                     and not self._pyfilesystem_instance.isfile(os_path)


### PR DESCRIPTION
This merge changes the call to os.path.join() in fsmanager.py, which fails on Windows (see #149 ), with a call to fs.path.join(), which  works correctly.

I've not been able to test this by installing the package, as I'm not familiar with building node.js modules, but I have tested it by making the same change by hand in my installed site-packages/jupyter-fs.  This works for most regular directories, but fails for "My Pictures" etc. on Windows, which are fairly special directories.