### PR TITLE
Use PEP440 version spec

### DIFF
--- a/jupyterfs/tests/test_extension.py
+++ b/jupyterfs/tests/test_extension.py
@@ -16,7 +16,6 @@ from jupyterfs.metamanager import MetaManagerHandler
 
 class TestExtension:
     def test_load_jupyter_server_extension(self):
-
         m = MagicMock()
 
         m.web_app.settings = {}

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ test_requires = [
 ]
 
 dev_requires = test_requires + [
-    "black>=20.0*",
+    "black>=20.0",
     "bump2version>=1.0.0",
     "flake8>=3.7.8",
     "flake8-black>=0.2.1",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ test_requires = [
 ]
 
 dev_requires = test_requires + [
-    "black>=20.0",
+    "black>=23",
     "bump2version>=1.0.0",
     "flake8>=3.7.8",
     "flake8-black>=0.2.1",


### PR DESCRIPTION
Seems like setuptools>v66.0 will fail the installation if version specs are not conforming to PEP440.