### PR TITLE
Fix file download

### DIFF
--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -8,6 +8,8 @@
 from hashlib import md5
 import json
 import re
+
+from traitlets import default
 from tornado import web
 
 from jupyter_server.base.handlers import APIHandler
@@ -31,6 +33,10 @@ __all__ = ["MetaManager", "MetaManagerHandler"]
 
 class MetaManager(ContentsManager):
     copy_pat = re.compile(r"\-Copy\d*\.")
+    
+    @default("files_handler_params")
+    def _files_handler_params_default(self):
+        return {"path": self.root_dir}
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -33,7 +33,7 @@ __all__ = ["MetaManager", "MetaManagerHandler"]
 
 class MetaManager(ContentsManager):
     copy_pat = re.compile(r"\-Copy\d*\.")
-    
+
     @default("files_handler_params")
     def _files_handler_params_default(self):
         return {"path": self.root_dir}


### PR DESCRIPTION
Seems like `jupyterfs.metamanager.MetaManager` class do not set root directory that `ContentsManager` expects. When we try to download a file, it will throw an error that `path` is not set. This PR fixes it.