### PR TITLE
fix: Remove unnecessary copy method overload in MetaManager

### DIFF
--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -150,7 +150,7 @@ class MetaManagerShared:
     is_hidden = path_first_arg("is_hidden", False, sync=True)
     dir_exists = path_first_arg("dir_exists", False, sync=True)
     file_exists = path_kwarg("file_exists", "", False, sync=True)
-    exists = path_first_arg("exists", False, sync=False)
+    exists = path_first_arg("exists", False, sync=True)
 
     save = path_second_arg("save", "model", True, sync=True)
     rename = path_old_new("rename", False, sync=True)
@@ -170,9 +170,6 @@ class SyncMetaManager(MetaManagerShared, ContentsManager): ...
 
 
 class MetaManager(MetaManagerShared, AsyncContentsManager):
-    async def copy(self, from_path, to_path=None):
-        return super(MetaManagerShared, self).copy(from_path=from_path, to_path=to_path)
-
     is_hidden = path_first_arg("is_hidden", False, sync=False)
     dir_exists = path_first_arg("dir_exists", False, sync=False)
     file_exists = path_kwarg("file_exists", "", False, sync=False)


### PR DESCRIPTION
Copy Paste functionality is broken with the current `1.0.0` version. It seems to be due to unnecessary overloading of `copy` method in `MetaManager`. 

```
2024-06-13 15:15:54,850 - ServerApp - ERROR - Uncaught exception POST /api/contents?1718284554848 (127.0.0.1)
HTTPServerRequest(protocol='http', host='localhost:8888', method='POST', uri='/api/contents?1718284554848', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/tornado/web.py", line 1790, in _execute
    result = await result
             ^^^^^^^^^^^^
  File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/auth/decorator.py", line 73, in inner
    return await out
           ^^^^^^^^^
  File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 277, in post
    await self._copy(copy_from, path)
  File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 217, in _copy
    validate_model(model)
  File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 69, in validate_model
    missing = required_keys - set(model.keys())
                                  ^^^^^^^^^^
AttributeError: 'coroutine' object has no attribute 'keys'
[W 2024-06-13 15:15:54.851 ServerApp] wrote error: 'Unhandled error'
    Traceback (most recent call last):
      File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/tornado/web.py", line 1790, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/auth/decorator.py", line 73, in inner
        return await out
               ^^^^^^^^^
      File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 277, in post
        await self._copy(copy_from, path)
      File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 217, in _copy
        validate_model(model)
      File "/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/jupyter_server/services/contents/handlers.py", line 69, in validate_model
        missing = required_keys - set(model.keys())
                                      ^^^^^^^^^^
    AttributeError: 'coroutine' object has no attribute 'keys'
[E 2024-06-13 15:15:54.852 ServerApp] {
      "Host": "localhost:8888",
      "Accept": "*/*",
      "Referer": "http://localhost:8888/lab",
      "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
    }
[E 2024-06-13 15:15:54.852 ServerApp] 500 POST /api/contents?1718284554848 (708cf5e2a6bc4b5b9d4cf7bc003d8217@127.0.0.1) 2.61ms referer=http://localhost:8888/lab
/home/paipuri/Documents/repos/jupyter/jupyterlab/.venv/lib/python3.11/site-packages/tornado/web.py:1801: RuntimeWarning: coroutine 'AsyncContentsManager.copy' was never awaited
  if self._prepared_future is not None and not self._prepared_future.done():
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This PR fixes it by removing the overloaded method.

In `MetaManagerShared`, the `sync` argument for `exists` method is set to `False` which fails the `jupyterfs` when `SyncMetaManager` is used. The argument has been corrected and set to `True`.