### PR TITLE
Add kwargs passthrough to backend driver, implement openWith

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -95,7 +95,6 @@
     "mkdirp": "^3.0.1",
     "rimraf": "^6.0.1",
     "shx": "^0.3.4",
-    "source-map-loader": "^4.0.2",
     "ts-jest": "^29.2.5",
     "typescript": "^4.9.5"
   },

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       shx:
         specifier: ^0.3.4
         version: 0.3.4
-      source-map-loader:
-        specifier: ^4.0.2
-        version: 4.0.2(webpack@5.98.0)
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.4))(typescript@4.9.5)
@@ -3535,12 +3532,6 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
 
-  source-map-loader@4.0.2:
-    resolution: {integrity: sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      webpack: ^5.72.1
-
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -5134,23 +5125,23 @@ snapshots:
       '@lumino/widgets': 2.6.0
       ajv: 8.17.1
       commander: 9.5.0
-      css-loader: 6.11.0(webpack@5.98.0)
+      css-loader: 6.11.0(webpack@5.98.0(webpack-cli@5.1.4))
       duplicate-package-checker-webpack-plugin: 3.0.0
       fs-extra: 10.1.0
       glob: 7.1.7
-      license-webpack-plugin: 2.3.21(webpack@5.98.0)
-      mini-css-extract-plugin: 2.9.2(webpack@5.98.0)
+      license-webpack-plugin: 2.3.21(webpack@5.98.0(webpack-cli@5.1.4))
+      mini-css-extract-plugin: 2.9.2(webpack@5.98.0(webpack-cli@5.1.4))
       mini-svg-data-uri: 1.4.4
       path-browserify: 1.0.1
       process: 0.11.10
-      source-map-loader: 1.0.2(webpack@5.98.0)
-      style-loader: 3.3.4(webpack@5.98.0)
+      source-map-loader: 1.0.2(webpack@5.98.0(webpack-cli@5.1.4))
+      style-loader: 3.3.4(webpack@5.98.0(webpack-cli@5.1.4))
       supports-color: 7.2.0
-      terser-webpack-plugin: 5.3.11(webpack@5.98.0)
+      terser-webpack-plugin: 5.3.11(webpack@5.98.0(webpack-cli@5.1.4))
       webpack: 5.98.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.98.0)
       webpack-merge: 5.10.0
-      worker-loader: 3.0.8(webpack@5.98.0)
+      worker-loader: 3.0.8(webpack@5.98.0(webpack-cli@5.1.4))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -5870,17 +5861,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.98.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.98.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.98.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.98.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.98.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.98.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.98.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.98.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.98.0)
@@ -6299,7 +6290,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.11.0(webpack@5.98.0):
+  css-loader@6.11.0(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.2)
       postcss: 8.5.2
@@ -7818,7 +7809,7 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
-  license-webpack-plugin@2.3.21(webpack@5.98.0):
+  license-webpack-plugin@2.3.21(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       '@types/webpack-sources': 0.1.12
       webpack-sources: 1.4.3
@@ -7904,7 +7895,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.98.0):
+  mini-css-extract-plugin@2.9.2(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
@@ -8492,19 +8483,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@1.0.2(webpack@5.98.0):
+  source-map-loader@1.0.2(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       data-urls: 2.0.0
       iconv-lite: 0.6.3
       loader-utils: 2.0.4
       schema-utils: 2.7.1
       source-map: 0.6.1
-      webpack: 5.98.0(webpack-cli@5.1.4)
-
-  source-map-loader@4.0.2(webpack@5.98.0):
-    dependencies:
-      iconv-lite: 0.6.3
-      source-map-js: 1.2.1
       webpack: 5.98.0(webpack-cli@5.1.4)
 
   source-map-support@0.5.13:
@@ -8624,7 +8609,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.98.0):
+  style-loader@3.3.4(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       webpack: 5.98.0(webpack-cli@5.1.4)
 
@@ -8648,7 +8633,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.11(webpack@5.98.0):
+  terser-webpack-plugin@5.3.11(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -8877,9 +8862,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.98.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.98.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.98.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.98.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.98.0))(webpack@5.98.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -8926,7 +8911,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(webpack@5.98.0)
+      terser-webpack-plugin: 5.3.11(webpack@5.98.0(webpack-cli@5.1.4))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -9010,7 +8995,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  worker-loader@3.0.8(webpack@5.98.0):
+  worker-loader@3.0.8(webpack@5.98.0(webpack-cli@5.1.4)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0

--- a/js/schema/plugin.json
+++ b/js/schema/plugin.json
@@ -54,7 +54,7 @@
           "enum": ["pyfs", "fsspec"],
           "default": "pyfs"
         },
-        "preferred_dir": {
+        "preferredDir": {
           "description": "Directory to be first opened (e.g., myDir/mySubdir)",
           "type": "string"
         },
@@ -68,6 +68,11 @@
           "description": "Fallback for determining if resource is writeable. Used only if the underlying PyFilesystem does not provide this information (eg S3)",
           "type": "boolean",
           "default": true
+        },
+        "kwargs": {
+          "description": "Generic kwargs JSON to pass through to resource construction, for any arguments that cannot go in the resource url",
+          "type": "string",
+          "default": "{}"
         }
       }
     },

--- a/js/src/clipboard.ts
+++ b/js/src/clipboard.ts
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { WidgetTracker, showErrorMessage } from "@jupyterlab/apputils";
 import { Drive } from "@jupyterlab/services";
 import { ClipboardModel, ContentsModel, IContentRow, Path } from "@tree-finder/base";

--- a/js/src/commands.ts
+++ b/js/src/commands.ts
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { JupyterFrontEnd } from "@jupyterlab/application";
 import { Dialog, showDialog } from "@jupyterlab/apputils";

--- a/js/src/commands.ts
+++ b/js/src/commands.ts
@@ -9,6 +9,7 @@
 
 import { JupyterFrontEnd } from "@jupyterlab/application";
 import { Dialog, showDialog } from "@jupyterlab/apputils";
+import { DocumentRegistry } from "@jupyterlab/docregistry";
 import {
   closeIcon,
   copyIcon,
@@ -20,9 +21,12 @@ import {
   refreshIcon,
   fileIcon,
   newFolderIcon,
+  RankedMenu,
+  IDisposableMenuItem,
 } from "@jupyterlab/ui-components";
+import { map } from "@lumino/algorithm";
 import { DisposableSet, IDisposable } from "@lumino/disposable";
-import { Menu } from "@lumino/widgets";
+import { ContextMenu, Menu } from "@lumino/widgets";
 import { Content, Path } from "@tree-finder/base";
 
 
@@ -42,6 +46,7 @@ export const commandNames = [
   "cut",
   "delete",
   "open",
+  "openWith",
   "paste",
   "refresh",
   "rename",
@@ -116,12 +121,14 @@ async function _commandKeyForSnippet(snippet: Snippet): Promise<string>  {
   return `jupyterfs:snippet-${snippet.label}-${await _digestString(snippet.label + snippet.caption + snippet.pattern.source + snippet.template)}`;
 }
 
+function _openWithKeyForFactory(factory: string): string  {
+  return `jupyterfs:openwith-${factory}`;
+}
 
 function _normalizedUrlForSnippet(content: Content<ContentsProxy.IJupyterContentRow>, baseUrl: string): string {
   const path = splitPathstrDrive(content.pathstr)[1];
   return `${baseUrl}/${path}${content.hasChildren ? "/" : ""}`;
 }
-
 
 /**
  * Create commands that will have the same IDs indepent of settings/resources
@@ -189,6 +196,7 @@ export function createStaticCommands(
       label: "Open",
       isEnabled: () => !!tracker.currentWidget,
     }),
+
     app.commands.addCommand(commandIDs.paste, {
       execute: args => clipboard.model.pasteSelection(tracker.currentWidget!.treefinder.model!),
       icon: pasteIcon,
@@ -420,6 +428,64 @@ export async function createDynamicCommands(
     }));
   }
 
+  const openWithCommands = [] as IDisposable[];
+  const openWithMenu = new Menu({ commands: app.commands });
+  openWithMenu.title.label = "Open With";
+  openWithMenu.id = "treefinder:open-with";
+  const { docRegistry } = app;
+
+  let items: IDisposableMenuItem[] = [];
+
+  function updateOpenWithMenu(contextMenu: ContextMenu) {
+    const openWith =
+      (contextMenu.menu.items.find(
+        item =>
+          item.type === "submenu" &&
+          item.submenu?.id === "treefinder:open-with"
+      )?.submenu as RankedMenu) ?? null;
+
+    if (!openWith) {
+      return; // Bail early if the open with menu is not displayed
+    }
+
+    // clear the current menu items
+    // items.forEach(item => item.dispose());
+    items.length = 0;
+    // Ensure that the menu is empty
+    openWith.clearItems();
+
+    // clear the commands
+    openWithCommands.forEach(item => item.dispose());
+    openWithCommands.length = 0;
+
+    // get the widget factories that could be used to open all of the items
+    // in the current filebrowser selection
+    const widget = tracker.currentWidget!;
+    const treefinder = widget.treefinder;
+    const model = treefinder.model!;
+    const factories = tracker.currentWidget
+      ? intersection<DocumentRegistry.WidgetFactory>(
+        map(model.selection, i => getFactories(docRegistry, widget, i))
+      )
+      : new Set<DocumentRegistry.WidgetFactory>();
+
+    // make new menu items from the widget factories
+    items = [...factories].map(factory => {
+      const key = _openWithKeyForFactory(factory.label || factory.name);
+      const label = factory.label || factory.name;
+      openWithCommands.push(app.commands.addCommand(key, {
+        execute: args => Promise.all(Array.from(map(model.selection, item => app.commands.execute("docmanager:open", { path: Path.fromarray(item.row.path), ...args })))),
+        label,
+        isVisible: () => true,
+      }));
+      return openWith.addItem({
+        args: { factory: factory.name, label: factory.label || factory.name },
+        command: key,
+      });
+    });
+  }
+  app.contextMenu.opened.connect(updateOpenWithMenu);
+
   const selector = ".jp-tree-finder-sidebar";
   let contextMenuRank = 1;
 
@@ -433,7 +499,12 @@ export async function createDynamicCommands(
       selector,
       rank: contextMenuRank++,
     }),
-
+    app.contextMenu.addItem({
+      type: "submenu",
+      submenu: openWithMenu,
+      selector,
+      rank: contextMenuRank++,
+    }),
     app.contextMenu.addItem({
       command: commandIDs.copy,
       selector,
@@ -520,4 +591,47 @@ export async function createDynamicCommands(
   ].reduce((set: DisposableSet, d) => {
     set.add(d); return set;
   }, new DisposableSet());
+}
+
+
+export function getFactories(
+  docRegistry: DocumentRegistry,
+  widget: TreeFinderSidebar,
+  item: Content<ContentsProxy.IJupyterContentRow>,
+): DocumentRegistry.WidgetFactory[] {
+  const path = [widget.url.trimEnd().replace(/\/+$/, ""), item.getPathAtDepth(1).join("/")].join("/");
+  const factories = docRegistry.preferredWidgetFactories(path);
+  const notebookFactory = docRegistry.getWidgetFactory("notebook");
+  if (
+    notebookFactory &&
+    item.row.kind === "notebook" &&
+    factories.indexOf(notebookFactory) === -1
+  ) {
+    factories.unshift(notebookFactory);
+  }
+  return factories;
+}
+
+function intersection<T>(iterables: Iterable<Iterable<T>>): Set<T> {
+  let accumulator: Set<T> | undefined;
+  for (const current of iterables) {
+    // Initialize accumulator.
+    if (accumulator === undefined) {
+      accumulator = new Set(current);
+      continue;
+    }
+    // Return early if empty.
+    if (accumulator.size === 0) {
+      return accumulator;
+    }
+    // Keep the intersection of accumulator and current.
+    const intersection_set = new Set<T>();
+    for (const value of current) {
+      if (accumulator.has(value)) {
+        intersection_set.add(value);
+      }
+    }
+    accumulator = intersection_set;
+  }
+  return accumulator ?? new Set();
 }

--- a/js/src/contents_utils.ts
+++ b/js/src/contents_utils.ts
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { Content, ContentsModel, IContentRow } from "@tree-finder/base";
 

--- a/js/src/filesystem.ts
+++ b/js/src/filesystem.ts
@@ -62,7 +62,13 @@ export interface IFSSettingsResource {
   /**
    * Directory to be first opened
    */
-  preferred_dir?: string;
+  preferredDir?: string;
+
+  /**
+   * Generic arguments to pass through to instantiation, for elements
+   * that cannot be placed in the resource url. Represented as JSON
+   */
+  kwargs?: JSON;
 }
 
 
@@ -79,7 +85,6 @@ export interface IFSResource extends IFSSettingsResource {
    * The fsurl specifying this resource
    */
   url: string;
-
 
   /**
    * The jupyterlab drive name associated with this resource. This is defined
@@ -109,6 +114,7 @@ export interface IFSResource extends IFSSettingsResource {
    * Any errors during initialization
    */
   errors?: string[];
+
 }
 
 export interface IFSComm {

--- a/js/src/index.tsx
+++ b/js/src/index.tsx
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { ILayoutRestorer, IRouter, JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
 import { IThemeManager, IWindowResolver } from "@jupyterlab/apputils";
@@ -13,7 +14,7 @@ import { IDocumentManager } from "@jupyterlab/docmanager";
 import { ISettingRegistry } from "@jupyterlab/settingregistry";
 import { IStatusBar } from "@jupyterlab/statusbar";
 import { ITranslator } from "@jupyterlab/translation";
-import { folderIcon, fileIcon, IFormRendererRegistry } from "@jupyterlab/ui-components";
+import { folderIcon, fileIcon, notebookIcon, IFormRendererRegistry } from "@jupyterlab/ui-components";
 import { IDisposable } from "@lumino/disposable";
 import * as semver from "semver";
 
@@ -180,12 +181,13 @@ export const browser: JupyterFrontEndPlugin<ITreeFinderMain> = {
     style.setAttribute("id", "jupyter-fs-icon-inject");
 
     // Hackish, but needed since free-finder insists on pseudo elements for icons.
-    function iconStyleContent(folderStr: string, fileStr: string) {
+    function iconStyleContent(folderStr: string, fileStr: string, notebookStr: string) {
       // Note: We aren't able to style the hover/select colors with this.
       return `
       .jp-tree-finder {
         --tf-dir-icon: url('data:image/svg+xml,${encodeURIComponent(folderStr)}');
         --tf-file-icon: url('data:image/svg+xml,${encodeURIComponent(fileStr)}');
+        --tf-notebook-icon: url('data:image/svg+xml,${encodeURIComponent(notebookStr)}');
       }
       `;
     }
@@ -196,7 +198,8 @@ export const browser: JupyterFrontEndPlugin<ITreeFinderMain> = {
       const primary = getComputedStyle(document.documentElement).getPropertyValue("--jp-ui-font-color1");
       style.textContent = iconStyleContent(
         folderIcon.svgstr.replace(/fill="([^"]{0,7})"/, `fill="${primary}"`),
-        fileIcon.svgstr.replace(/fill="([^"]{0,7})"/, `fill="${primary}"`)
+        fileIcon.svgstr.replace(/fill="([^"]{0,7})"/, `fill="${primary}"`),
+        notebookIcon.svgstr.replace(/fill="([^"]{0,7})"/, `fill="${primary}"`)
       );
 
       // Refresh widgets in case font/border sizes etc have changed
@@ -215,7 +218,7 @@ export const browser: JupyterFrontEndPlugin<ITreeFinderMain> = {
       }
     });
 
-    style.textContent = iconStyleContent(folderIcon.svgstr, fileIcon.svgstr);
+    style.textContent = iconStyleContent(folderIcon.svgstr, fileIcon.svgstr, notebookIcon.svgstr);
 
     document.head.appendChild(style);
 

--- a/js/src/progress.tsx
+++ b/js/src/progress.tsx
@@ -6,6 +6,7 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 /* Based on code from JupyterLab, copied under the following license:
 

--- a/js/src/treefinder.ts
+++ b/js/src/treefinder.ts
@@ -199,7 +199,12 @@ export class TreeFinderWidget extends DragDropWidget {
 
   async nodeInit() {
     // The contents of root passed to node.init is not (currently) considered, so do not ask for it.
-    const root = await this.contentsProxy.get(this.rootPath, { content: false });
+    let root = null;
+    try {
+      root = await this.contentsProxy.get(this.rootPath, { content: false });
+    } catch (error) {
+      return;
+    }
     this._currentFolder = this.model?.root.pathstr;
     await this.node.init({
       root,
@@ -718,9 +723,9 @@ export namespace TreeFinderSidebar {
     return sidebar({
       ...props,
       rootPath: resource.drive,
-      caption: `${resource.name}\nFile Tree`,
+      caption: resource.name,
       id: idFromResource(resource),
-      preferredDir: resource.preferred_dir,
+      preferredDir: resource.preferredDir,
       url: resource.url,
       type: resource.type,
     });

--- a/js/src/treefinder.ts
+++ b/js/src/treefinder.ts
@@ -1,11 +1,12 @@
 /******************************************************************************
  *
  * Copyright (c) 2019, the jupyter-fs authors.
- *
- * This file is part of the jupyter-fs library, distributed under the terms of
- * the Apache License 2.0.  The full license can be found in the LICENSE file.
- *
- */
+*
+* This file is part of the jupyter-fs library, distributed under the terms of
+* the Apache License 2.0.  The full license can be found in the LICENSE file.
+*
+*/
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ILayoutRestorer, IRouter, JupyterFrontEnd } from "@jupyterlab/application";
 import {
   Dialog,
@@ -200,6 +201,7 @@ export class TreeFinderWidget extends DragDropWidget {
   async nodeInit() {
     // The contents of root passed to node.init is not (currently) considered, so do not ask for it.
     let root = null;
+
     try {
       root = await this.contentsProxy.get(this.rootPath, { content: false });
     } catch (error) {

--- a/js/style/treefinder.css
+++ b/js/style/treefinder.css
@@ -172,6 +172,11 @@ tree-finder-panel tree-finder-grid table {
   min-width: 1em;
 }
 
+/* treefinder comes with file/directory icons, so inject notebook icon */
+.jp-tree-finder tree-finder-grid .tf-grid-notebook-icon:before {
+  background-image: var(--tf-notebook-icon);
+}
+
 .jp-tree-finder span.rt-tree-group {
   height: 100%;
   margin-left: 0.45em;

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -132,6 +132,12 @@ class MetaManagerShared:
                             resource.get("name"),
                         )
                         errors.append(str(e))
+                    except ImportError as e:
+                        self.log.exception(
+                            "Missing dependencies to create manager for resource %r",
+                            resource.get("name"),
+                        )
+                        errors.append(str(e))
 
             # assemble resource from spec + hash
             newResource = {}

--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -74,6 +74,14 @@ class MetaManagerShared:
                 resource["type"] = "pyfs"
                 self.log.warning("Resource %r missing 'type' key, defaulting to 'pyfs'", resource)
 
+            if resource.get("kwargs", None):
+                if isinstance(resource["kwargs"], str):
+                    try:
+                        resource["kwargs"] = json.loads(resource["kwargs"])
+                    except json.JSONDecodeError:
+                        self.log.warning("Resource %r has invalid kwargs, defaulting to '{}'", resource)
+                        resource["kwargs"] = {}
+
             # get deterministic hash of PyFilesystem url
             _hash = md5(resource["url"].encode("utf-8")).hexdigest()[:8]
             init = False
@@ -112,7 +120,10 @@ class MetaManagerShared:
                             urlSubbed,
                             default_writable=default_writable,
                             parent=self,
-                            **self._pyfs_kw,
+                            **{
+                                **self._pyfs_kw,
+                                **resource.get("kwargs", {}),
+                            },
                         )
                         init = True
                     except FileSystemLoadError as e:


### PR DESCRIPTION
Builds on https://github.com/jpmorganchase/jupyter-fs/pull/231

- Adds a kwargs passthrough for fsspec, e.g. for passthrough of backend_url/key/secret to `s3fs`. 
- Implements `Open With` context menu entry with correct factories, partially duplicating the [jupyterlab open with plugin](https://github.com/jupyterlab/jupyterlab/blob/5ba4755e5a64eae5bb1ce807dd6bc06b6e908273/packages/filebrowser-extension/src/index.ts#L666C7-L666C15) fixes #193 
- Handle missing python dependencies fixes #241
- Add notebook icons in file tree