### PR TITLE
Release alpha candidate of 1.1.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-fs",
-  "version": "1.0.1",
+  "version": "1.1.0rc0",
   "description": "A Filesystem-like mult-contents manager backend for Jupyter",
   "author": "The jupyter-fs authors",
   "license": "Apache-2.0",

--- a/jupyterfs/__init__.py
+++ b/jupyterfs/__init__.py
@@ -12,7 +12,7 @@ from .extension import _jupyter_server_extension_points
 from .fs_wrapper import fs, fs_instance
 from .metamanager import MetaManager, SyncMetaManager
 
-__version__ = "1.0.1"
+__version__ = "1.1.0rc0"
 
 __all__ = (
     "_jupyter_labextension_paths",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "the jupyter-fs authors", email = "t.paine154@gmail.com"}]
 description = "A Filesystem-like mult-contents manager backend for Jupyter"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-version = "1.0.1"
+version = "1.1.0rc0"
 requires-python = ">=3.9"
 keywords = [
     "Jupyter",
@@ -90,7 +90,7 @@ Repository = "https://github.com/jpmorganchase/jupyter-fs"
 Homepage = "https://github.com/jpmorganchase/jupyter-fs"
 
 [tool.bumpversion]
-current_version = "1.0.1"
+current_version = "1.1.0rc0"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "the jupyter-fs authors", email = "t.paine154@gmail.com"}]
 description = "A Filesystem-like mult-contents manager backend for Jupyter"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-version = "0.1.0"
+version = "1.0.1"
 requires-python = ">=3.9"
 keywords = [
     "Jupyter",
@@ -90,7 +90,7 @@ Repository = "https://github.com/jpmorganchase/jupyter-fs"
 Homepage = "https://github.com/jpmorganchase/jupyter-fs"
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "1.0.1"
 commit = true
 tag = true
 


### PR DESCRIPTION
Note that I didnt want to do https://github.com/callowayproject/bump-my-version?tab=readme-ov-file#visualize-the-new-versioning-path so we'll have to bump to 1.1.0 manually which is fine and easy to do.