### PR TITLE
Fix pre-existing ESLint warnings in auth.tsx and commands.ts

### DIFF
--- a/js/src/auth.tsx
+++ b/js/src/auth.tsx
@@ -230,9 +230,9 @@ export class AskDialog<
     this.props.handleClose();
   }
 
-  protected async _onSubmit(
+  protected _onSubmit(
     event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> {
+  ): void {
     event.preventDefault();
 
     this.props.handleSubmit(this.state.values);

--- a/js/src/commands.ts
+++ b/js/src/commands.ts
@@ -110,11 +110,12 @@ function _getRelativePaths(selectedFiles: Array<Content<ContentsProxy.IJupyterCo
 
 
 function _digestString(value: string): string {
+  // eslint-disable-next-line no-bitwise
   return value.split("").reduce((a: number, b: string) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0).toString(16);
 }
 
 
-async function _commandKeyForSnippet(snippet: Snippet): Promise<string>  {
+function _commandKeyForSnippet(snippet: Snippet): string {
   return `jupyterfs:snippet-${snippet.label}-${_digestString(snippet.label + snippet.caption + snippet.pattern.source + snippet.template)}`;
 }
 
@@ -350,7 +351,7 @@ export function createStaticCommands(
       },
     }),
     app.commands.addCommand(commandIDs.newLauncher, {
-      execute: async args => {
+      execute: _args => {
         void app.commands.execute("launcher:create");
       },
       label: "New Launcher",
@@ -400,7 +401,7 @@ export async function createDynamicCommands(
   const snippetCommands = [] as IDisposable[];
   const snippetIds = new Set<string>();
   for (const snippet of snippets) {
-    const key = await _commandKeyForSnippet(snippet);
+    const key = _commandKeyForSnippet(snippet);
     if (snippetIds.has(key)) {
       console.warn("Discarding duplicate snippet", snippet);
       continue;


### PR DESCRIPTION
- Remove unnecessary async from AskDialog._onSubmit (plain React event handler)
- Add eslint-disable comment for intentional bitwise ops in _digestString (djb2 hash)
- Remove unnecessary async from _commandKeyForSnippet (sync computation, no await inside)
- Update call site to drop redundant await on now-sync _commandKeyForSnippet
- Remove unnecessary async from newLauncher execute handler