### PR TITLE
Add pkg_resources backport to fs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ develop = [
     "boto3",
     "fs-miniofs",
     "pysmb",
+    "pkg-resources-backport>=1.0.1",
     # fs
     "fs>=2.4.11",
     "fs-s3fs>=1.1.1",
@@ -88,6 +89,7 @@ fs = [
     "fs>=2.4.11",
     "fs-s3fs>=1.1.1",
     "fs.smbfs>=0.6.3",
+    "pkg-resources-backport>=1.0.1",
 ]
 fsspec = [
     "fsspec>=2023.6.0",


### PR DESCRIPTION
## Summary

Fixes #373 by adding `pkg-resources-backport` to the PyFilesystem optional dependency set.

`fs` 2.4.16 imports `pkg_resources` during import. In environments with setuptools 82+, `pkg_resources` is no longer present, so `jupyter-fs[fs]` can fail before an `osfs://` manager is created. The backport restores that module for the `fs` extra and the development extra that installs the same PyFilesystem dependencies.

## Tests

- Reproduced in a fresh Python 3.13 venv that `import fs` fails with `ModuleNotFoundError: No module named 'pkg_resources'` when `pkg-resources-backport` is absent.
- `python - <<'PY' ...` checked that `pkg-resources-backport>=1.0.1` is present in both `project.optional-dependencies.fs` and `project.optional-dependencies.develop`.
- `python - <<'PY' ...` verified `import fs` and `open_fs('mem://')` work after installing the backport.