### PR TITLE
metamanager: raise clear error when resource name contains a space

### DIFF
--- a/jupyterfs/metamanager.py
+++ b/jupyterfs/metamanager.py
@@ -66,6 +66,16 @@ class MetaManagerShared:
         managers = dict((("", self._default_root_manager),))
 
         for resource in resources:
+            # Validate the resource name: spaces are not allowed because the name is
+            # used to construct widget IDs and path-like identifiers in the frontend,
+            # which silently drop spaces and can cause duplicate IDs or broken widgets.
+            name = resource.get("name", "")
+            if " " in name:
+                raise ValueError(
+                    f"Resource name {name!r} contains a space. "
+                    "Resource names must not contain spaces."
+                )
+
             # server side resources don't have a default 'auth' key
             if "auth" not in resource or resource["auth"] not in ("ask", "env", "none"):
                 self.log.warning("Resource %r missing 'auth' key, defaulting to 'ask'", resource)
@@ -285,4 +295,8 @@ class MetaManagerHandler(APIHandler):
             if not isinstance(resource, dict):
                 raise web.HTTPError(400, f"Resources must be a list of dicts, got: {resource}")
 
-        self.finish(json.dumps(self.contents_manager.initResource(*resources, options=options)))
+        try:
+            result = self.contents_manager.initResource(*resources, options=options)
+        except ValueError as e:
+            raise web.HTTPError(400, str(e))
+        self.finish(json.dumps(result))

--- a/jupyterfs/tests/test_metamanager.py
+++ b/jupyterfs/tests/test_metamanager.py
@@ -179,6 +179,26 @@ async def test_resource_validators_no_auth(tmp_path, jp_fetch, jp_server_config,
 
 @pytest.mark.parametrize("base_config", [base_config, sync_base_config])
 @pytest.mark.parametrize("our_config", [{}])
+async def test_resource_name_with_space_raises(tmp_path, jp_fetch, jp_server_config):
+    """Resource names containing spaces should be rejected with a 400 error.
+
+    A name like "homedir fsspec" is used to build widget IDs in the frontend
+    by stripping spaces (resource.name.split(" ").join("")), which silently
+    produces duplicate IDs when two names differ only by spacing. Rejecting
+    such names early gives users a clear error message.
+    """
+    from tornado.httpclient import HTTPClientError
+
+    cc = ContentsClient(jp_fetch)
+    with pytest.raises(HTTPClientError) as exc_info:
+        await cc.set_resources(
+            [{"name": "homedir fsspec", "url": f"osfs://{tmp_path.as_posix()}"}]
+        )
+    assert exc_info.value.code == 400
+
+
+@pytest.mark.parametrize("base_config", [base_config, sync_base_config])
+@pytest.mark.parametrize("our_config", [{}])
 async def test_basic_sanity_check(tmp_path, jp_fetch, jp_server_config):
     cc = ContentsClient(jp_fetch)
     resources = await cc.get("/")


### PR DESCRIPTION
## Summary

- Resource names with spaces currently fail silently or with an opaque error
- The frontend's `idFromResource` strips spaces when building widget IDs (`resource.name.split(" ").join("")`), so `"homedir fsspec"` and `"homedirfsspec"` produce the same widget ID — causing silent duplicate panels or a broken filetree with no user-visible message
- `initResource` now raises `ValueError` immediately if a name contains a space
- `MetaManagerHandler.post` catches that and returns HTTP 400 with the error text, so the client gets a clear message instead of a silent failure

## Test plan

- [ ] New test `test_resource_name_with_space_raises` verifies that POSTing a resource with `"name": "homedir fsspec"` returns HTTP 400
- [ ] Existing test suite (`pytest jupyterfs/`) continues to pass

Fixes #303